### PR TITLE
Handle NSC ("no significant clouds") sky condition

### DIFF
--- a/src/decode_metar.c
+++ b/src/decode_metar.c
@@ -833,6 +833,20 @@ static MDSP_BOOL isSkyConditions( char **skycond, Decoded_METAR *Mptr,
       return TRUE;
    }
  
+      // interrogate skycond to determine if "NSC" is present
+ 
+   else if( strcmp(*skycond,"NSC") == 0)
+   {
+      strcpy(Mptr->cloudGroup[0].cloud_type,"NSC");
+/*
+      memset(Mptr->cloudGroup[0].cloud_hgt_char,'\0',1);
+      memset(Mptr->cloudGroup[0].other_cld_phenom,
+              '\0', 1);
+*/
+      (*NDEX)++;
+      return TRUE;
+   }
+ 
       // interrogate skycond to determine if
       //    vertical visibility is present
  


### PR DESCRIPTION
Handle the NSC sky condition like mdsplib currently handles CLR and SKC (ie, set the cloud type to NSC).