### PR TITLE
Remove unused charPrevailVsby member

### DIFF
--- a/include/metar.h
+++ b/include/metar.h
@@ -165,7 +165,6 @@ typedef struct decoded_METAR {
    char PartialObscurationAmt[MAX_PARTIAL_OBSCURATIONS][7];
    char PartialObscurationPhenom[MAX_PARTIAL_OBSCURATIONS][12];
    char SfcObscuration[MAX_SURFACE_OBSCURATIONS][10];
-   char charVertVsby[10];
    char TS_LOC[3];
    char TS_MOVMNT[3];
  

--- a/include/metar.h
+++ b/include/metar.h
@@ -165,7 +165,6 @@ typedef struct decoded_METAR {
    char PartialObscurationAmt[MAX_PARTIAL_OBSCURATIONS][7];
    char PartialObscurationPhenom[MAX_PARTIAL_OBSCURATIONS][12];
    char SfcObscuration[MAX_SURFACE_OBSCURATIONS][10];
-   char charPrevailVsby[12];
    char charVertVsby[10];
    char TS_LOC[3];
    char TS_MOVMNT[3];

--- a/src/print_decoded_metar.c
+++ b/src/print_decoded_metar.c
@@ -860,12 +860,6 @@ void sprint_metar (char * string, Decoded_METAR *Mptr)
       strcat(string, temp);
    }
  
- /*
-   if( Mptr->charVertVsby[0] != '\0' )
-      sprintf(temp, "Vert. Vsby (CHAR)   : %s\n",
-                  Mptr->charVertVsby );
- */
- 
    if ( Mptr->QFE != MAXINT ) {
       sprintf(temp, "QFE                 : %d\n", Mptr->QFE);
       strcat(string, temp);

--- a/src/print_decoded_metar.c
+++ b/src/print_decoded_metar.c
@@ -188,12 +188,7 @@ void sprint_metar (char * string, Decoded_METAR *Mptr)
       sprintf(temp, "PREVAIL VSBY (SM)   : %.3f\n",Mptr->prevail_vsbySM);
       strcat(string, temp);
    }
-/*
-   if ( Mptr->charPrevailVsby[0] != '\0' ) {
-      sprintf(temp, "PREVAIL VSBY (CHAR) : %s\n",Mptr->charPrevailVsby);
-      strcat(string, temp);
-   }
-*/
+
    if ( Mptr->vsby_Dir[ 0 ] != '\0' ) {
       sprintf(temp, "VISIBILITY DIRECTION: %s\n",Mptr->vsby_Dir);
       strcat(string, temp);


### PR DESCRIPTION
* The charPrevailVsby member of the decoded_METAR struct was never initialized or used anywhere, so remove it (not even sure what its intended use was)
* Also remove charVertVsby as it is never initialized, set or used