### PR TITLE
Add visibilityIsUpperBound to metar struct, fix peak wind decoding

### DIFF
--- a/include/metar.h
+++ b/include/metar.h
@@ -210,7 +210,8 @@ typedef struct decoded_METAR {
    MDSP_BOOL OVHD_LTG;
    MDSP_BOOL LightningVCTS;
    MDSP_BOOL LightningTS;
- 
+   MDSP_BOOL visibilityIsUpperBound;
+
    int  TornadicDistance;
    int  ob_hour;
    int  ob_minute;

--- a/src/decode_metar.c
+++ b/src/decode_metar.c
@@ -1078,11 +1078,18 @@ static MDSP_BOOL isMBeforeVis( char **m, Decoded_METAR *Mptr,
 {
     (void)Mptr;
 
+    /*
+     * NB: If the visibility string is not preceded by a token with just
+     *     an M, the M may be part of the visibility string itself.
+     *     That case is handled with the rest of the visibility string
+     *     code.
+     */
+
     if (*m == NULL) {
         return FALSE;
     }
 
-    if (strncmp(*m, "M ", 2) == 0) {
+    if (strncmp(*m, "M ", 2) == 0 || strncmp(*m, "< ", 2) == 0) {
         (*NDEX)++;
         return TRUE;
     }
@@ -1130,9 +1137,9 @@ static MDSP_BOOL isVisibility( char **visblty, Decoded_METAR *Mptr,
    /*
     * Some visibility strings start with 'M' to indicate that they
     * are actually some value less than the stated quantity, ie,
-    * < 1/4 SM is 'M1/4SM'.
+    * < 1/4 SM is 'M1/4SM'. Rarely, '<' appears in place of 'M'.
     */
-   if (*visblty[0] == 'M') {
+   if (*visblty[0] == 'M' || *visblty[0] == '<') {
        visblty[0]++;
        isVisAfterM = isVisibility(visblty, Mptr, NDEX);
        visblty[0]--;
@@ -1141,15 +1148,6 @@ static MDSP_BOOL isVisibility( char **visblty, Decoded_METAR *Mptr,
            return isVisAfterM;
        }
        return isVisAfterM;
-   }
-
-   // CHECK FOR VISIBILITY MEASURED <1/4SM
-
-   if( strcmp(*visblty,"<1/4SM") == 0 ) {
-      Mptr->visibilityIsUpperBound = TRUE;
-      Mptr->prevail_vsbySM = 0.25;
-      (*NDEX)++;
-      return TRUE;
    }
 
    // CHECK FOR VISIBILITY MISSING

--- a/src/decode_metar.c
+++ b/src/decode_metar.c
@@ -1135,11 +1135,11 @@ static MDSP_BOOL isVisibility( char **visblty, Decoded_METAR *Mptr,
    if (*visblty[0] == 'M') {
        visblty[0]++;
        isVisAfterM = isVisibility(visblty, Mptr, NDEX);
+       visblty[0]--;
        if (isVisAfterM) {
            Mptr->visibilityIsUpperBound = TRUE;
            return isVisAfterM;
        }
-       visblty[0]--;
        return isVisAfterM;
    }
 

--- a/src/decode_metar.c
+++ b/src/decode_metar.c
@@ -249,6 +249,7 @@ static void init_metar_decoder( Decoded_METAR *Mptr )
    Mptr->VcyStn_LTG    = FALSE;
    Mptr->LightningVCTS = FALSE;
    Mptr->LightningTS   = FALSE;
+   Mptr->visibilityIsUpperBound = FALSE;
  
    memset( Mptr->LTG_DIR, '\0', sizeof(Mptr->LTG_DIR));
  
@@ -1029,8 +1030,7 @@ static float prevailingVisibility( char *visibility )
         *SM_KM_ptr;
    char numerator[3],
         denominator[3];
- 
- 
+
    if( (SM_KM_ptr = strstr( visibility, "SM" )) == NULL )
       SM_KM_ptr = strstr(visibility, "KM");
  
@@ -1067,7 +1067,28 @@ static float prevailingVisibility( char *visibility )
    }
  
 }
- 
+
+/*
+ * Occasionally, visibility strings are preceded by "M ", indicating
+ * that the actual visibility is something less than the value
+ * in question, eg, M 1/4SM = 'less than 0.25 sm'
+ */
+static MDSP_BOOL isMBeforeVis( char **m, Decoded_METAR *Mptr,
+                               int *NDEX )
+{
+    (void)Mptr;
+
+    if (*m == NULL) {
+        return FALSE;
+    }
+
+    if (strncmp(*m, "M ", 2) == 0) {
+        (*NDEX)++;
+        return TRUE;
+    }
+    return FALSE;
+}
+
 #pragma subtitle(" ")
 #pragma page(1)
 #pragma subtitle("subtitle - description                       ")
@@ -1101,17 +1122,32 @@ static MDSP_BOOL isVisibility( char **visblty, Decoded_METAR *Mptr,
    char *achar,
         *astring,
         *save_token;
- 
- 
-   // CHECK FOR VISIBILITY MEASURED <1/4SM
- 
+   MDSP_BOOL isVisAfterM;
+
    if( *visblty == NULL )
-      return FALSE;
- 
- 
-   if( strcmp(*visblty,"M1/4SM") == 0 ||
-       strcmp(*visblty,"<1/4SM") == 0 ) {
-      Mptr->prevail_vsbySM = 0.0;
+       return FALSE;
+
+   /*
+    * Some visibility strings start with 'M' to indicate that they
+    * are actually some value less than the stated quantity, ie,
+    * < 1/4 SM is 'M1/4SM'.
+    */
+   if (*visblty[0] == 'M') {
+       visblty[0]++;
+       isVisAfterM = isVisibility(visblty, Mptr, NDEX);
+       if (isVisAfterM) {
+           Mptr->visibilityIsUpperBound = TRUE;
+           return isVisAfterM;
+       }
+       visblty[0]--;
+       return isVisAfterM;
+   }
+
+   // CHECK FOR VISIBILITY MEASURED <1/4SM
+
+   if( strcmp(*visblty,"<1/4SM") == 0 ) {
+      Mptr->visibilityIsUpperBound = TRUE;
+      Mptr->prevail_vsbySM = 0.25;
       (*NDEX)++;
       return TRUE;
    }
@@ -2678,8 +2714,15 @@ printf("decode_metar:  token[%d] = %s\n",NDEX,token[NDEX]);
             MetarGroup = visibility;
             break;
          case( visibility ):
-            if( isVisibility( &(token[NDEX]), Mptr, &NDEX ) )
-               SaveStartGroup = StartGroup = visibility;
+            if( isMBeforeVis( &(token[NDEX]), Mptr, &NDEX ) ) {
+                Mptr->visibilityIsUpperBound = TRUE;
+            }
+            if( isVisibility( &(token[NDEX]), Mptr, &NDEX ) ) {
+                SaveStartGroup = StartGroup = visibility;
+            } else if (Mptr->visibilityIsUpperBound) {
+                Mptr->visibilityIsUpperBound = FALSE;
+                NDEX--;
+            }
             MetarGroup = RVR;
             break;
          case( RVR ):

--- a/src/decode_metar_remark.c
+++ b/src/decode_metar_remark.c
@@ -894,6 +894,7 @@ static MDSP_BOOL isPeakWind( char **string, Decoded_METAR *Mptr,
  
       return FALSE;
    }
+   // dddff(f)/(hh)mm
    else if( strlen(*string) >= 8 && strlen(*string) <= 11 &&
              nisdigit(slash+1,strlen(slash+1)) &&
              nisdigit(*string, (slash - *string)) &&
@@ -901,7 +902,7 @@ static MDSP_BOOL isPeakWind( char **string, Decoded_METAR *Mptr,
              (slash - *string) <= 6 )
    {
       memset( buf, '\0', 4);
-      strncpy( buf, *string, slash - *string );
+      strncpy( buf, *string, 3 );
       Mptr->PKWND_dir = atoi( buf );
  
       memset( buf, '\0', 4);

--- a/src/decode_metar_remark.c
+++ b/src/decode_metar_remark.c
@@ -852,7 +852,7 @@ static MDSP_BOOL isPeakWind( char **string, Decoded_METAR *Mptr,
 {
    char buf[ 32 ];
    char *slash;
-   int temp;
+   int timeAsInt;
    MDSP_BOOL PK_WND_FLAG;
  
    /* IF THE CURRENT AND NEXT GROUPS ARE "PK WND", THEN  */
@@ -910,15 +910,16 @@ static MDSP_BOOL isPeakWind( char **string, Decoded_METAR *Mptr,
  
       memset( buf, '\0', 5);
       strcpy( buf, slash+1 );
-      temp             =  atoi( buf );
+      timeAsInt         =  atoi( buf );
  
-      if( temp > 99 )
+      if( strlen(buf) > 2 )
       {
-         Mptr->PKWND_hour = atoi(buf)/100;
-         Mptr->PKWND_minute = (atoi(buf)) % 100;
+         Mptr->PKWND_hour = timeAsInt/100;
+         Mptr->PKWND_minute = timeAsInt % 100;
       }
-      else
-         Mptr->PKWND_minute =  atoi( buf );
+      else if (timeAsInt < 60) {
+         Mptr->PKWND_minute = timeAsInt;
+      }
                               /* VALID PEAK WIND FOUND.  BUMP */
                               /* PAST PK, WND, AND PEAK WIND  */
                               /* GROUPS AND RETURN TRUE.      */


### PR DESCRIPTION
Add a new field to the decoded metar struct, `visibilityIsUpperBound`. This field is set to `MDSP_TRUE` when the metar received has a visibility string "up to" a particular distance (eg, 'M1/4SM' or 'M1SM'), and `MDSP_FALSE` otherwise.

This PR also fixes two bugs in peak wind decoding:

1. If a peak wind measurement was taken between 00:00Z and 00:59Z (inclusive), the `PKWND_hour` field would not be set.

2. When parsing the peak wind direction (`PKWND_dir`), the wind speed was appended to the direction. For example, given the remark `PK WND 12010/1115`, ("peak wind, 120 degrees, 10 knots, measured at 11:15Z") the direction would be erroneously decoded as `12010`.