### PR TITLE
Fix compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.a
 src/*.o
 metar_test
+metar_test.exe

--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,15 @@ install: library
 
 test:	metar_test
 	./metar_test
+
+.PHONY : clean
+clean:
+ifeq ($(OS), Windows_NT)
+	echo off
+	del /q src\*.o
+	del /q metar_test.exe 
+	del /q libmetar.a
+	echo on
+else
+	rm -f libmetar.a src/*.o src/*.a metar_test
+endif

--- a/include/metar.h
+++ b/include/metar.h
@@ -38,7 +38,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /********************************************************************/
  
 /* Used in the METAR structs. */
+#ifndef mdsp_bool
+#define mdsp_bool
 typedef unsigned short int MDSP_BOOL;
+#endif
 
 #define MAX_RUNWAYS 12
 #define MAX_CLOUD_GROUPS 6

--- a/src/decode_metar.c
+++ b/src/decode_metar.c
@@ -1314,103 +1314,6 @@ static MDSP_BOOL isVisibility( char **visblty, Decoded_METAR *Mptr,
  
 }
  
-/********************************************************************/
-/*                                                                  */
-/*  Title:         variableVisibility                               */
-/*  Organization:  W/OSO242 - GRAPHICS AND DISPLAY SECTION          */
-/*  Date:          15 Sep 1994                                      */
-/*  Programmer:    CARL MCCALLA                                     */
-/*  Language:      C/370                                            */
-/*                                                                  */
-/*  Abstract:                                                       */
-/*                                                                  */
-/*  External Functions Called:                                      */
-/*                 None.                                            */
-/*                                                                  */
-/*  Input:         x                                                */
-/*                                                                  */
-/*  Output:        x                                                */
-/*                                                                  */
-/*  Modification History:                                           */
-/*                 None.                                            */
-/*                                                                  */
-/********************************************************************/
-
-static MDSP_BOOL variableVisibility( char *string1, char *string2,
-                      Decoded_METAR *Mptr, int *NDEX )
-{
-   char buf[ 32 ];
-   int numerator,
-       denominator;
-   char *slash,
-        *V_char,
-        *temp;
- 
-   if( string1 == NULL )
-      return FALSE;
- 
-   V_char = strchr(string1,'V');
-   slash =  strchr(string1,'/');
- 
-   if(slash == NULL)
-   {
-      if(nisdigit(string1,V_char-string1))
-      {
-         memset(buf, '\0', sizeof(buf));
-         strncpy(buf, string1, V_char-string1);
- 
-         if( Mptr->minVsby != (float) MAXINT )
-            Mptr->minVsby += (float) atoi(buf);
-         else
-            Mptr->minVsby  = (float) atoi(buf);
- 
-         memset(buf, '\0', sizeof(buf));
-         strncpy(buf, V_char+1, 5);
-         Mptr->maxVsby = (float) atoi(buf);
- 
-      }
-      else
-         return FALSE;
-   }
-   else
-   {
-      temp = (char *) malloc(sizeof(char)*((V_char-string1)+1));
-      memset(temp, '\0', (V_char-string1) +1);
-      strncpy(temp, string1, V_char-string1);
-      if( Mptr->minVsby != MAXINT )
-         Mptr->minVsby += fracPart(temp);
-      else
-         Mptr->minVsby = fracPart(temp);
- 
-      free( temp );
- 
-      if( strchr(V_char+1,'/') != NULL)
-         Mptr->maxVsby = fracPart(V_char+1);
-      else
-         Mptr->maxVsby = (float) atoi(V_char+1);
-   }
- 
-   if( string2 == NULL )
-      return TRUE;
-   else
-   {
-      slash = strchr( string2, '/' );
- 
-      if( slash == NULL )
-         return TRUE;
-      else
-      {
-         if( nisdigit(string2,slash-string2) &&
-             nisdigit(slash+1,strlen(slash+1)) )
-         {
-            Mptr->maxVsby += fracPart(string2);
-            (*NDEX)++;
-         }
-         return TRUE;
-      }
-   }
- 
-}
  
 /********************************************************************/
 /*                                                                  */
@@ -1742,43 +1645,6 @@ static MDSP_BOOL isTempGroup( char *token, Decoded_METAR *Mptr, int *NDEX)
 }
  
  
-/********************************************************************/
-/*                                                                  */
-/*  Title:         isWxToken                                        */
-/*  Organization:  W/OSO242 - GRAPHICS AND DISPLAY SECTION          */
-/*  Date:          15 Sep 1994                                      */
-/*  Programmer:    CARL MCCALLA                                     */
-/*  Language:      C/370                                            */
-/*                                                                  */
-/*  Abstract:                                                       */
-/*                                                                  */
-/*  External Functions Called:                                      */
-/*                 None.                                            */
-/*                                                                  */
-/*  Input:         x                                                */
-/*                                                                  */
-/*  Output:        x                                                */
-/*                                                                  */
-/*  Modification History:                                           */
-/*                 None.                                            */
-/*                                                                  */
-/********************************************************************/
- 
-static MDSP_BOOL isWxToken( char *token )
-{
-   int i;
- 
-   if( token == NULL )
-      return FALSE;
-   for( i = 0; i < strlen(token); i++ )
-   {
-      if( !(isalpha(*(token+i)) || *(token+i) == '+' ||
-                                   *(token+i) == '-' ||
-                                   *(token+i) == '/'  ) )
-         return FALSE;
-   }
-   return TRUE;
-}
  
 /********************************************************************/
 /*                                                                  */
@@ -2211,8 +2077,6 @@ static char* defaultWindUnitsForAirport( char *airportId )
    static char *airportPrefixUsingMPS[1] = { "Z" },
                *airportPrefixWithoutDefault[1] = { "U" };
 
-   char airportPrefix = airportId[0];
-
    /* Check that an ICAO airport code has been passed in. */
    if( strlen(airportId) != 4 ) {
       return "";
@@ -2259,8 +2123,8 @@ static MDSP_BOOL isWindData( char *wind, Decoded_METAR *Mptr, int *NDEX )
 {
  
    char *GustPtr,
-        *unitsPtr,
-        *defaultUnit;
+        *unitsPtr;
+   
    char dummy[8];
  
    if( wind == NULL )
@@ -2447,14 +2311,9 @@ int decode_metar( char *string , Decoded_METAR *Mptr )
                                       SaveStartGroup,
                                       MetarGroup;
  
-   WindStruct *WinDataPtr;
- 
+
    int    ndex,
-          NDEX,
-          i,
-          jkj,
-          j;
- 
+          NDEX;
  
    char   **token,
           *delimeters = {" "},
@@ -2516,6 +2375,7 @@ if( strcmp(token[0],"OPKC") == 0 || strcmp(token[0],"TAPA") == 0 ) {
     if( strcmp( token[NDEX], "RMK" ) != 0 ) {
  
       StartGroup = NotIDed;
+      SaveStartGroup = StartGroup;
  
 #ifdef DEBUGZZ
 if( strcmp(token[0],"OPKC") == 0 || strcmp(token[0],"TAPA") == 0 ) {

--- a/src/decode_metar_remark.c
+++ b/src/decode_metar_remark.c
@@ -71,8 +71,7 @@ float fracPart( char * );
 static MDSP_BOOL isTS_LOC( char **string, Decoded_METAR *Mptr,
                            int *NDEX )
 {
-   int i;
- 
+   
    /* COMPARE THE INPUT CHARACTER STRING WITH */
    /* VALID AUTOMATED STATION CODE TYPE.  IF  */
    /* A MATCH IS FOUND, RETURN TRUE.  OTHER-  */
@@ -81,8 +80,7 @@ static MDSP_BOOL isTS_LOC( char **string, Decoded_METAR *Mptr,
    if( *string == NULL )
       return FALSE;
  
-   i = 0;
- 
+   
    if( strcmp( *string, "TS") != 0 )
       return FALSE;
    else {
@@ -1789,11 +1787,10 @@ static MDSP_BOOL isVisibility2ndSite( char **token, Decoded_METAR *Mptr,
  
 MDSP_BOOL static isLightningFrequency( char **string, Decoded_METAR *Mptr, int *NDEX )
 {
-   MDSP_BOOL LTG_FREQ_FLAG,
-        LTG_TYPE_FLAG,
-        LTG_LOC_FLAG,
-        LTG_DIR_FLAG,
-        TYPE_NOT_FOUND;
+   MDSP_BOOL LTG_TYPE_FLAG,
+      LTG_LOC_FLAG,
+      LTG_DIR_FLAG,
+      TYPE_NOT_FOUND;
    char *temp;
  
    // if the current group is "LTG", then determine
@@ -1829,20 +1826,15 @@ MDSP_BOOL static isLightningFrequency( char **string, Decoded_METAR *Mptr, int *
       (--string);
  
  
-      LTG_FREQ_FLAG = FALSE;
-
     // check for lightning frequency
       if( strcmp( *string, "OCNL" ) == 0 ) {
          Mptr->OCNL_LTG = TRUE;
-         LTG_FREQ_FLAG = TRUE;
       }
       else if( strcmp( *string, "FRQ" ) == 0 ) {
          Mptr->FRQ_LTG = TRUE;
-         LTG_FREQ_FLAG = TRUE;
       }
       else if( strcmp( *string, "CONS" ) == 0 ) {
          Mptr->CNS_LTG = TRUE;
-         LTG_FREQ_FLAG = TRUE;
       }
  
  
@@ -2696,8 +2688,7 @@ static MDSP_BOOL isPRESRR( char *string, Decoded_METAR *Mptr, int *NDEX)
  
 static MDSP_BOOL isSLP( char **token, Decoded_METAR *Mptr, int *NDEX )
 {
-   int pressure,
-       ndex;
+   int pressure;
  
    if( *token == NULL )
       return FALSE;
@@ -2765,6 +2756,7 @@ static MDSP_BOOL isSectorVsby( char **string, Decoded_METAR *Mptr,
        tempstrlen = 20;
  
    float vsby;
+   vsby = FLT_MAX;
    char  dd[3],
          temp[20],
          *slash;
@@ -4663,13 +4655,9 @@ void decode_metar_remark(char **token, Decoded_METAR *Mptr)
        FZRANO = 0, TSNO = 0, maintIndicator = 0, CHINO = 0, RVRNO = 0,
        VISNO = 0, PNO = 0, DVR = 0;
  
-	int  NDEX, ndex, i;
+	int  NDEX, i;
 
-	char *slash, *tokenX, *V_char, *temp_token;
- 
-	MDSP_BOOL extra_token, IS_NOT_RMKS;
- 
-	float T_vsby;
+	MDSP_BOOL IS_NOT_RMKS;
  
 	NDEX = 0;
  

--- a/src/local.h
+++ b/src/local.h
@@ -135,7 +135,11 @@ void freex(void *, char *, int);
  
 typedef unsigned char byte;
  
+#ifndef mdsp_bool
+#define mdsp_bool
 typedef unsigned short int MDSP_BOOL;
+#endif
+
  
 typedef unsigned short int Devaddr;
  


### PR DESCRIPTION
I'm working on creating an R package that wraps `mdsplib`, called [RMETAR](https://github.com/jwijffels/RMETAR).  To get the package on CRAN (the Comprehensive R Archive Network), my package should pass all compiler warnings. CRAN compiles with `gcc -Wall`.

This PR attempts to fix most compiler warnings:
* Unused variables
* Uninitialized variables

Related issue: https://github.com/jwijffels/RMETAR/issues/11
